### PR TITLE
Enhance pre-commit hooks to match CI/CD checks

### DIFF
--- a/.devtooling/configs/.lintstagedrc.json
+++ b/.devtooling/configs/.lintstagedrc.json
@@ -1,3 +1,9 @@
 {
-  "*.{ts,js,tsx,jsx}": ["biome format --write"]
+  "*.{ts,js,tsx,jsx}": ["biome check --write"],
+  "*.{json,yaml,yml,md}": [
+    "prettier --config .devtooling/configs/.prettierrc.json --ignore-path .devtooling/configs/.prettierignore --write"
+  ],
+  "*.md": ["markdownlint-cli2 --config .devtooling/configs/.markdownlint-cli2.jsonc --fix"],
+  "*.json": [".devtooling/scripts/lint-json.sh"],
+  "*.{yaml,yml}": [".devtooling/scripts/lint-yaml.sh"]
 }

--- a/test_precommit.md
+++ b/test_precommit.md
@@ -1,1 +1,0 @@
-# Test file for pre-commit hooks

--- a/test_precommit.md
+++ b/test_precommit.md
@@ -1,0 +1,1 @@
+# Test file for pre-commit hooks


### PR DESCRIPTION
## Summary
- Enhanced lint-staged configuration to include all CI/CD checks
- Pre-commit hooks now run Prettier, Markdownlint, JSONlint, and YAMLlint
- Prevents CI/CD failures by catching formatting issues locally

## Test plan
- [x] Pre-commit hooks tested and working
- [x] All linters run correctly during commit
- [x] Matches CI/CD pipeline checks